### PR TITLE
SPM-39/ Fixed PDF Templates list view not loading due to invalid sort column

### DIFF
--- a/superset/pdf_templates/api.py
+++ b/superset/pdf_templates/api.py
@@ -143,20 +143,15 @@ class PdfTemplateRestApi(BaseSupersetModelRestApi):
         "changed_by.last_name",
         "changed_by.id",
         "changed_by_name",
-        # "changed_on_delta_humanized",
+        "changed_on_delta_humanized",
         "changed_on_dttm",
         "changed_on_utc",
         "created_by.first_name",
         "created_by.id",
         "created_by.last_name",
         "created_by_name",
-        # "created_on_delta_humanized",
         "description",
         "id",
-        # "last_saved_at",
-        # "last_saved_by.id",
-        # "last_saved_by.first_name",
-        # "last_saved_by.last_name",
         "owners.first_name",
         "owners.id",
         "owners.last_name",
@@ -169,11 +164,7 @@ class PdfTemplateRestApi(BaseSupersetModelRestApi):
     list_select_columns = list_columns + ["changed_by_fk", "changed_on"]
     order_columns = [
         "changed_by.first_name",
-        # "changed_on_delta_humanized"
-        # "last_saved_at",
-        # "last_saved_by.id",
-        # "last_saved_by.first_name",
-        # "last_saved_by.last_name",
+        "changed_on_delta_humanized",
         "name",
     ]
     search_columns = [


### PR DESCRIPTION
Jira ticket - [SPM-39](https://fajr.atlassian.net/browse/SPM-39)

Fixed PDF Templates list view not loading due to invalid sort column configuration. The default sort column `changed_on_delta_humanized` was commented out in the API's `order_columns` list causing a server error when trying to sort by this column.

Pdf Templates page screenshot - 
![image](https://github.com/user-attachments/assets/a0dc6bd2-f021-4f5b-873a-aa6d30acbfef)
