### PR TITLE
SPM-47/ Fixed Edit button on PDF Template list page

### DIFF
--- a/superset-frontend/src/features/pdf_templates/PdfTemplateCard.tsx
+++ b/superset-frontend/src/features/pdf_templates/PdfTemplateCard.tsx
@@ -123,7 +123,7 @@ export default function PdfTemplateCard({
             data-test="PdfTemplate-list-edit-option"
             role="button"
             tabIndex={0}
-            // onClick={() => openPdfTemplateEditModal(PdfTemplate)}
+            onClick={() => history.push(`/pdf_template/${PdfTemplate.id}`)}
           >
             <Icons.EditAlt iconSize="l" /> {t('Edit')}
           </div>

--- a/superset-frontend/src/pages/PdfDesigner/PdfmeDesignerComponent.tsx
+++ b/superset-frontend/src/pages/PdfDesigner/PdfmeDesignerComponent.tsx
@@ -233,10 +233,20 @@ const PdfMeDesignerComponent = () => {
     };
 
     try {
-      const rv = await makeApi<JsonObject, JsonObject>({
-        method: 'POST',
-        endpoint: 'api/v1/pdf_template/',
-      })(payload);
+      let rv;
+      if (id) {
+        // Update existing template
+        rv = await makeApi<JsonObject, JsonObject>({
+          method: 'PUT',
+          endpoint: `api/v1/pdf_template/${id}`,
+        })(payload);
+      } else {
+        // Create new template
+        rv = await makeApi<JsonObject, JsonObject>({
+          method: 'POST',
+          endpoint: 'api/v1/pdf_template/',
+        })(payload);
+      }
 
       if (rv?.id) {
         alert('Template saved successfully! ID: ' + rv.id);
@@ -253,7 +263,7 @@ const PdfMeDesignerComponent = () => {
       );
       console.error('Save Error:', clientError);
     }
-  }, [name, description, designerRef]);
+  }, [name, description, designerRef, id]);
 
   const onSaveTemplate = () => {
     setIsModalOpen(true);

--- a/superset-frontend/src/pages/PdfTemplateList/index.tsx
+++ b/superset-frontend/src/pages/PdfTemplateList/index.tsx
@@ -379,15 +379,14 @@ import PdfTemplateCard from 'src/features/pdf_templates/PdfTemplateCard';
                     title={t('Edit')}
                     placement="bottom"
                   >
-                    {/* Should navigate to PDF Designer */}
-                    {/* <span
+                    <span
                       role="button"
                       tabIndex={0}
                       className="action-button"
-                      onClick={openEditModal}
+                      onClick={() => history.push(`/pdf_template/${original.id}`)}
                     >
                       <Icons.EditAlt data-test="edit-alt" />
-                    </span> */}
+                    </span>
                   </Tooltip>
                 )}
               </StyledActions>
@@ -413,6 +412,7 @@ import PdfTemplateCard from 'src/features/pdf_templates/PdfTemplateCard';
         refreshData,
         addSuccessToast,
         addDangerToast,
+        history,
       ],
     );
   

--- a/superset/pdf_templates/schemas.py
+++ b/superset/pdf_templates/schemas.py
@@ -170,6 +170,9 @@ class PdfTemplatePutSchema(Schema):
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True)
     tags = fields.List(fields.Integer(metadata={"description": tags_description}))
+    data = fields.Dict(
+        metadata={"description": data_description}
+    )
 
 
 class PdfTemplateGetDatasourceObjectDataResponseSchema(Schema):


### PR DESCRIPTION
Jira ticket - [SPM-47](https://fajr.atlassian.net/browse/SPM-47)

Implemented navigation to the PDF designer from the edit button in both the list and card views by updating the onClick handlers to use history.push with the template ID.